### PR TITLE
check USE_MODEL before including fft.h in src/makeit.c

### DIFF
--- a/src/makeit.c
+++ b/src/makeit.c
@@ -43,7 +43,9 @@
 #include	"assoc.h"
 #include	"back.h"
 #include	"check.h"
+#ifdef USE_MODEL 
 #include	"fft.h"
+#endif
 #include	"field.h"
 #include	"filter.h"
 #include	"growth.h"


### PR DESCRIPTION
When configured with --disable-model-fitting option, SExtractor fails to compile with the following error:
~~~~
mv -f .deps/main.Tpo .deps/main.Po
gcc -DHAVE_CONFIG_H -I. -I..     -g -O2 -MT makeit.o -MD -MP -MF .deps/makeit.Tpo -c -o makeit.o makeit.c
In file included from makeit.c:47:
fft.h:34:10: error: #include expects "FILENAME" or <FILENAME>
 #include FFTW_H
          ^~~~~~
make[3]: *** [Makefile:628: makeit.o] Error 1
~~~~
This can be fixed by adding USE_MODEL definition check in src/makeit.c around including fft.h
~~~~
#ifdef USE_MODEL 
#include        "fft.h"
#endif
~~~~