### PR TITLE
Switch finite to std::isfinite for ICC and GCC

### DIFF
--- a/src/levmar/compiler.h
+++ b/src/levmar/compiler.h
@@ -60,7 +60,12 @@
 #ifdef _MSC_VER
 #define LM_FINITE _finite // MSVC
 #elif defined(__ICC) || defined(__INTEL_COMPILER) || defined(__GNUC__)
-#define LM_FINITE finite // ICC, GCC
+#  ifdef __APPLE__
+#  include <math.h>
+#  define LM_FINITE isfinite // Apple
+#  else
+#  define LM_FINITE finite // ICC, GCC
+#  endif
 #else
 #define LM_FINITE finite // other than MSVC, ICC, GCC, let's hope this will work
 #endif


### PR DESCRIPTION
This supports latest compilers on Mac OS X, see https://github.com/Homebrew/homebrew-core/pull/181246